### PR TITLE
refactor: decouple client and RESTHandler

### DIFF
--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -1,23 +1,18 @@
-import RESTManager from '../rest/RESTManager';
+import { ClientOptions } from '../rest/RequestHandler';
+import { RESTManager } from '../rest/RESTManager';
 import { Clan } from '../struct/Clan';
 import Util from '../util/Util';
 
 export class Client {
-	public keys: string[];
-	public baseURL: string;
-	public restRequestTimeout: number;
+	private readonly rest: RESTManager;
+	public readonly util = Util;
 
-	public util = Util;
-	public rest = new RESTManager(this);
-
-	public constructor(options: ClientOptions = {}) {
-		this.keys = options.keys ?? [];
-		this.restRequestTimeout = options.restRequestTimeout ?? 0;
-		this.baseURL = options.baseURL ?? 'https://api.clashofclans.com/v1';
+	public constructor(options?: ClientOptions) {
+		this.rest = new RESTManager(options);
 	}
 
 	public setkeys(keys: string[]) {
-		this.keys = keys;
+		this.rest.handler.setKeys(keys);
 		return this;
 	}
 
@@ -25,10 +20,4 @@ export class Client {
 		const { data } = await this.rest.getClan(clanTag);
 		return new Clan(this, data);
 	}
-}
-
-export interface ClientOptions {
-	keys?: string[];
-	baseURL?: string;
-	restRequestTimeout?: number;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './client/Client';
+export * from './rest/RESTManager';

--- a/src/rest/RESTManager.ts
+++ b/src/rest/RESTManager.ts
@@ -1,5 +1,5 @@
-import RequestHandler from './RequestHandler';
-import { Client } from '../client/Client';
+import { RequestHandler, ClientOptions } from './RequestHandler';
+import { encodeTag } from '../util/Util';
 
 import {
 	APIClan,
@@ -26,13 +26,11 @@ import {
 	APIWarLeagueList
 } from '../types';
 
-export default class RESTManager {
-	private readonly client: Client;
-	private readonly handler: RequestHandler;
+export class RESTManager {
+	public readonly handler: RequestHandler;
 
-	public constructor(client: Client) {
-		this.client = client;
-		this.handler = new RequestHandler(client);
+	public constructor(options?: ClientOptions) {
+		this.handler = new RequestHandler(options);
 	}
 
 	public getClans(options: ClanSearchOptions) {
@@ -152,7 +150,7 @@ export default class RESTManager {
 	}
 
 	private encodeTag(tag: string) {
-		return this.client.util.encodeTag(tag);
+		return encodeTag(tag);
 	}
 
 	private getQueryString(options = {}) {

--- a/src/rest/RequestHandler.ts
+++ b/src/rest/RequestHandler.ts
@@ -1,21 +1,24 @@
-import { Client } from '../client/Client';
-import HTTPError from './HTTPError';
 import fetch from 'node-fetch';
 import https from 'https';
+import HTTPError from './HTTPError';
 
 const agent = new https.Agent({ keepAlive: true });
 
-export default class RequestHandler {
+export class RequestHandler {
 	#keyIndex = 0; // eslint-disable-line
 
-	private readonly client: Client;
+	private keys: string[];
+	private readonly baseURL: string;
+	private readonly restRequestTimeout: number;
 
-	public constructor(client: Client) {
-		this.client = client;
+	public constructor(options?: ClientOptions) {
+		this.keys = options?.keys ?? [];
+		this.baseURL = options?.baseURL ?? 'https://api.clashofclans.com/v1';
+		this.restRequestTimeout = options?.restRequestTimeout ?? 0;
 	}
 
 	private get _keys() {
-		return Array.isArray(this.client.keys) ? this.client.keys : [this.client.keys];
+		return Array.isArray(this.keys) ? this.keys : [this.keys];
 	}
 
 	private get _key() {
@@ -24,14 +27,17 @@ export default class RequestHandler {
 		return key;
 	}
 
+	public setKeys(keys: string[]) {
+		this.keys = keys;
+	}
+
 	public async request<T = any>(path: string, options: RequestOptions = {}) {
-		const timeout = this.client.restRequestTimeout || 0;
-		const res = await fetch(`${this.client.baseURL}${path}`, {
+		const res = await fetch(`${this.baseURL}${path}`, {
 			headers: {
 				Authorization: `Bearer ${this._key}`,
 				'Content-Type': 'application/json'
 			},
-			timeout,
+			timeout: this.restRequestTimeout,
 			agent,
 			...options
 		}).catch(() => null);
@@ -47,4 +53,10 @@ export default class RequestHandler {
 export interface RequestOptions {
 	method?: string;
 	body?: string;
+}
+
+export interface ClientOptions {
+	keys?: string[];
+	baseURL?: string;
+	restRequestTimeout?: number;
 }


### PR DESCRIPTION
Now the Rest handler can be used without having to create a new client. i.e. open possibilities for the users who want to do raw API calls only