### PR TITLE
Removed unnecessary war state check

### DIFF
--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -170,7 +170,7 @@ export class Client extends EventEmitter {
 			return wars.find((war) => war.clan.tag === args.clanTag && war.state === state) ?? null;
 		}
 
-		return wars.find((war) => war.clan.tag === args.clanTag && war.state === state) ?? wars.at(0) ?? null;
+		return wars.find((war) => war.clan.tag === args.clanTag) ?? wars.at(0) ?? null;
 	}
 
 	private async _getCurrentLeagueWars(clanTag: string, options?: OverrideOptions) {

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -170,7 +170,7 @@ export class Client extends EventEmitter {
 			return wars.find((war) => war.clan.tag === args.clanTag && war.state === state) ?? null;
 		}
 
-		return wars.find((war) => war.clan.tag === args.clanTag) ?? wars.at(0) ?? null;
+		return wars.find((war) => war.clan.tag === args.clanTag) ?? null;
 	}
 
 	private async _getCurrentLeagueWars(clanTag: string, options?: OverrideOptions) {


### PR DESCRIPTION
Removed unnecessary war state check as war state check will not match our assumed war state while matching clantag is already found.