### PR TITLE
feat: use decorators to manage non-enumerable properties

### DIFF
--- a/src/client/PollingClient.ts
+++ b/src/client/PollingClient.ts
@@ -48,7 +48,7 @@ export class PollingClient extends Client {
 		this.inMaintenance = Boolean(false);
 		this._maintenanceStartTime = null;
 
-		if (typeof options?.pollingInterval !== 'number') {
+		if (options?.pollingInterval && typeof options.pollingInterval !== 'number') {
 			throw new Error('The property "pollingInterval" must be a type of number.');
 		}
 

--- a/src/client/PollingClient.ts
+++ b/src/client/PollingClient.ts
@@ -48,7 +48,7 @@ export class PollingClient extends Client {
 		this.inMaintenance = Boolean(false);
 		this._maintenanceStartTime = null;
 
-		if (options?.pollingInterval && !isNaN(options.pollingInterval)) {
+		if (options?.pollingInterval && isNaN(options.pollingInterval)) {
 			throw new Error('The property "pollingInterval" must be a type of number.');
 		}
 

--- a/src/client/PollingClient.ts
+++ b/src/client/PollingClient.ts
@@ -48,7 +48,7 @@ export class PollingClient extends Client {
 		this.inMaintenance = Boolean(false);
 		this._maintenanceStartTime = null;
 
-		if (options?.pollingInterval && isNaN(options.pollingInterval)) {
+		if (typeof options?.pollingInterval !== 'number') {
 			throw new Error('The property "pollingInterval" must be a type of number.');
 		}
 

--- a/src/struct/CapitalRaidSeason.ts
+++ b/src/struct/CapitalRaidSeason.ts
@@ -6,6 +6,7 @@ import {
 	APICapitalRaidSeasonMember,
 	OverrideOptions
 } from '../types';
+import { Enumerable } from '../util/Decorators';
 import { Util } from '../util/Util';
 import { Player } from './Player';
 
@@ -76,10 +77,11 @@ export class CapitalRaidSeason {
 	/** The defense log of the raid season. */
 	public defenseLog: APICapitalRaidSeasonDefenseLog[];
 
-	public constructor(
-		private readonly client: Client,
-		data: APICapitalRaidSeason
-	) {
+	@Enumerable(false)
+	private readonly client: Client;
+
+	public constructor(client: Client, data: APICapitalRaidSeason) {
+		this.client = client;
 		this.state = data.state;
 		this.startTime = Util.formatDate(data.startTime);
 		this.endTime = Util.formatDate(data.endTime);

--- a/src/struct/Clan.ts
+++ b/src/struct/Clan.ts
@@ -1,5 +1,6 @@
 import { Client } from '../client/Client';
 import { APICapitalLeague, APIChatLanguage, APIClan, APILabel, APIWarLeague, OverrideOptions } from '../types';
+import { Enumerable } from '../util/Decorators';
 import { Badge } from './Badge';
 import { ClanCapital } from './ClanCapital';
 import { ClanMember } from './ClanMember';
@@ -92,10 +93,11 @@ export class Clan {
 	 */
 	public members: ClanMember[];
 
-	public constructor(
-		public client: Client,
-		data: APIClan
-	) {
+	@Enumerable(false)
+	public readonly client: Client;
+
+	public constructor(client: Client, data: APIClan) {
+		this.client = client;
 		this.name = data.name;
 		this.tag = data.tag;
 		this.type = data.type;

--- a/src/struct/Clan.ts
+++ b/src/struct/Clan.ts
@@ -94,7 +94,7 @@ export class Clan {
 	public members: ClanMember[];
 
 	@Enumerable(false)
-	public readonly client: Client;
+	private readonly client: Client;
 
 	public constructor(client: Client, data: APIClan) {
 		this.client = client;

--- a/src/struct/ClanMember.ts
+++ b/src/struct/ClanMember.ts
@@ -1,6 +1,7 @@
 import { Client } from '../client/Client';
 import { APIClanMember, APILeague, APIPlayerHouse, OverrideOptions } from '../types';
 import { UnrankedLeagueData } from '../util/Constants';
+import { Enumerable } from '../util/Decorators';
 import { League } from './League';
 
 export class ClanMember {
@@ -46,10 +47,11 @@ export class ClanMember {
 	/** The member's player house details. */
 	public playerHouse?: APIPlayerHouse | null;
 
-	public constructor(
-		public client: Client,
-		data: APIClanMember
-	) {
+	@Enumerable(false)
+	public readonly client: Client;
+
+	public constructor(client: Client, data: APIClanMember) {
+		this.client = client;
 		this.name = data.name;
 		this.tag = data.tag;
 		// @ts-expect-error

--- a/src/struct/ClanMember.ts
+++ b/src/struct/ClanMember.ts
@@ -48,7 +48,7 @@ export class ClanMember {
 	public playerHouse?: APIPlayerHouse | null;
 
 	@Enumerable(false)
-	public readonly client: Client;
+	private readonly client: Client;
 
 	public constructor(client: Client, data: APIClanMember) {
 		this.client = client;

--- a/src/struct/ClanWar.ts
+++ b/src/struct/ClanWar.ts
@@ -1,6 +1,7 @@
 import { Client } from '../client/Client';
 import { APIClanWar, APIClanWarAttack, APIClanWarMember, APIWarClan } from '../types';
 import { FriendlyWarPreparationTimes } from '../util/Constants';
+import { Enumerable } from '../util/Decorators';
 import { getWarResult } from '../util/Helper';
 import { Badge } from './Badge';
 
@@ -238,8 +239,6 @@ export class WarClan {
  * :::
  */
 export class ClanWar {
-	public client!: Client;
-
 	/**
 	 * The clan's current war state.
 	 *
@@ -271,9 +270,11 @@ export class ClanWar {
 	/** The war's unique tag. This is `null` unless this is a CWL.  */
 	public warTag!: string | null;
 
-	public constructor(client: Client, data: APIClanWar, extra: { clanTag?: string; warTag?: string }) {
-		Object.defineProperty(this, 'client', { value: client });
+	@Enumerable(false)
+	public readonly client: Client;
 
+	public constructor(client: Client, data: APIClanWar, extra: { clanTag?: string; warTag?: string }) {
+		this.client = client;
 		this.state = data.state;
 		if (this.state !== 'notInWar') {
 			this.teamSize = data.teamSize;

--- a/src/struct/ClanWar.ts
+++ b/src/struct/ClanWar.ts
@@ -271,7 +271,7 @@ export class ClanWar {
 	public warTag!: string | null;
 
 	@Enumerable(false)
-	public readonly client: Client;
+	private readonly client: Client;
 
 	public constructor(client: Client, data: APIClanWar, extra: { clanTag?: string; warTag?: string }) {
 		this.client = client;

--- a/src/struct/ClanWarLeagueGroup.ts
+++ b/src/struct/ClanWarLeagueGroup.ts
@@ -1,5 +1,6 @@
 import { Client } from '../client/Client';
 import { APIClanWarLeagueClan, APIClanWarLeagueClanMember, APIClanWarLeagueGroup, APIClanWarLeagueRound, OverrideOptions } from '../types';
+import { Enumerable } from '../util/Decorators';
 import { Badge } from './Badge';
 import { ClanWar } from './ClanWar';
 import { Player } from './Player';
@@ -44,10 +45,11 @@ export class ClanWarLeagueClan {
 	/** An array of members that are in the CWL group. */
 	public members: ClanWarLeagueClanMember[];
 
-	public constructor(
-		private readonly client: Client,
-		data: APIClanWarLeagueClan
-	) {
+	@Enumerable(false)
+	private readonly client: Client;
+
+	public constructor(client: Client, data: APIClanWarLeagueClan) {
+		this.client = client;
 		this.name = data.name;
 		this.tag = data.tag;
 		this.level = data.clanLevel;
@@ -96,10 +98,11 @@ export class ClanWarLeagueGroup {
 	/** An array containing all war tags for each round. */
 	public rounds!: ClanWarLeagueRound[];
 
-	public constructor(
-		private readonly client: Client,
-		data: APIClanWarLeagueGroup
-	) {
+	@Enumerable(false)
+	private readonly client: Client;
+
+	public constructor(client: Client, data: APIClanWarLeagueGroup) {
+		this.client = client;
 		this.state = data.state;
 		if (this.state !== 'notInWar') {
 			this.season = data.season;

--- a/src/struct/ClanWarLog.ts
+++ b/src/struct/ClanWarLog.ts
@@ -1,5 +1,6 @@
 import { Client } from '../client/Client';
 import { APIClanWarLogEntry, APIWarLogClan } from '../types';
+import { Enumerable } from '../util/Decorators';
 import { Util } from '../util/Util';
 import { Badge } from './Badge';
 
@@ -76,10 +77,11 @@ export class ClanWarLog {
 	/** The opposition clan. */
 	public opponent: WarLogClan;
 
-	public constructor(
-		public client: Client,
-		data: APIClanWarLogEntry
-	) {
+	@Enumerable(false)
+	public readonly client: Client;
+
+	public constructor(client: Client, data: APIClanWarLogEntry) {
+		this.client = client;
 		this.result = data.result ?? null;
 		this.endTime = Util.formatDate(data.endTime);
 		this.teamSize = data.teamSize;

--- a/src/struct/ClanWarLog.ts
+++ b/src/struct/ClanWarLog.ts
@@ -78,7 +78,7 @@ export class ClanWarLog {
 	public opponent: WarLogClan;
 
 	@Enumerable(false)
-	public readonly client: Client;
+	private readonly client: Client;
 
 	public constructor(client: Client, data: APIClanWarLogEntry) {
 		this.client = client;

--- a/src/struct/Player.ts
+++ b/src/struct/Player.ts
@@ -1,6 +1,7 @@
 import { Client } from '../client/Client';
 import { APIPlayer, APIPlayerHouse, OverrideOptions } from '../types';
 import { BuilderTroops, HeroPets, HomeTroops, SiegeMachines, SuperTroops, UnrankedLeagueData } from '../util/Constants';
+import { Enumerable } from '../util/Decorators';
 import { Achievement } from './Achievement';
 import { Label } from './Label';
 import { League } from './League';
@@ -94,10 +95,11 @@ export class Player {
 	/** The player's clan capital house details. */
 	public playerHouse?: APIPlayerHouse | null;
 
-	public constructor(
-		public client: Client,
-		data: APIPlayer
-	) {
+	@Enumerable(false)
+	private readonly client: Client;
+
+	public constructor(client: Client, data: APIPlayer) {
+		this.client = client;
 		this.name = data.name;
 		this.tag = data.tag;
 		this.townHallLevel = data.townHallLevel;

--- a/src/struct/PlayerClan.ts
+++ b/src/struct/PlayerClan.ts
@@ -1,5 +1,6 @@
 import { Client } from '../client/Client';
 import { APIPlayerClan, OverrideOptions } from '../types';
+import { Enumerable } from '../util/Decorators';
 import { Badge } from './Badge';
 
 /** Represents a Player's clan. */
@@ -20,10 +21,11 @@ export class PlayerClan {
 	/** Badge of this clan. */
 	public badge: Badge;
 
-	public constructor(
-		private readonly _client: Client,
-		data: APIPlayerClan
-	) {
+	@Enumerable(false)
+	private readonly client: Client;
+
+	public constructor(client: Client, data: APIPlayerClan) {
+		this.client = client;
 		this.name = data.name;
 		this.tag = data.tag;
 		this.level = data.clanLevel ?? null; // eslint-disable-line
@@ -32,7 +34,7 @@ export class PlayerClan {
 
 	/** Fetch detailed clan info for the player's clan. */
 	public fetch(options?: OverrideOptions) {
-		return this._client.getClan(this.tag, options);
+		return this.client.getClan(this.tag, options);
 	}
 
 	/** Get clan's formatted link to open clan in-game. */

--- a/src/util/Decorators.ts
+++ b/src/util/Decorators.ts
@@ -1,0 +1,19 @@
+/**
+ * Decorator that sets the enumerable property of a class field to the desired value.
+ * @param value Whether the property should be enumerable or not
+ */
+export function Enumerable(value: boolean) {
+	return (target: unknown, key: string) => {
+		Reflect.defineProperty(target as object, key, {
+			enumerable: value,
+			set(this: unknown, val: unknown) {
+				Reflect.defineProperty(this as object, key, {
+					configurable: true,
+					enumerable: value,
+					value: val,
+					writable: true
+				});
+			}
+		});
+	};
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
 		"strict": true,
-		"skipLibCheck": true
+		"skipLibCheck": true,
+		"experimentalDecorators": true
 	},
 	"include": [
 		"src"


### PR DESCRIPTION
Fixes JSON.stringify() contains client property which expose keys
using a decorator seems to be more efficient than the toJSON() solution