### PR TITLE
Fix parseArmyLink method

### DIFF
--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -173,7 +173,7 @@ export class Util extends null {
 		const unitsMatches = /u(?<units>[\d+x-]+)/.exec(link);
 		const spellsMatches = /s(?<spells>[\d+x-]+)/.exec(link);
 
-		const unitsPart = (unitsMatches?.groups?.unit as string | null)?.split('-') ?? [];
+		const unitsPart = (unitsMatches?.groups?.units as string | null)?.split('-') ?? [];
 		const spellParts = (spellsMatches?.groups?.spells as string | null)?.split('-') ?? [];
 
 		const units = unitsPart


### PR DESCRIPTION
The method parseArmyLink was not returning null for armies as for this single s I guess as I have fixed it in my local machine and then trying to fix it in the main branch of original repo.